### PR TITLE
Removed horizontal scrolling on Contact Us Page

### DIFF
--- a/MOMOMIA/nav.css
+++ b/MOMOMIA/nav.css
@@ -17,7 +17,7 @@ footer {
   font-family: "Ubuntu", sans-serif;
   background-color: #0d1010;
   color: #ffc107;
-  padding: 3% 0 2% 0;
+  padding: 3% 2rem 2%;
 }
 
 .footerHeadingCol {
@@ -35,7 +35,6 @@ footer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding-right: 5%;
 }
 
 .socialMediaIcon /* individual icons styling */ {


### PR DESCRIPTION
In this PR, I have removed the horizontal scrolling on the ContactUs page due to the footer.
![image](https://user-images.githubusercontent.com/84830429/198712294-3de7e8df-f9e7-470f-b42a-01fd4e24f0f3.png)